### PR TITLE
Consolidate config ymls + add sandboxes token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ longitude: <YOUR_LONGITUDE>
 Open separate terminals to run the following commands. If you are using a virtual environment, ensure that the virtual environment is activated for all terminals.
 
 ```bash
-python auto-reconnaissance/main.py --config auto-reconnaissance/var/config.yml
+python auto-reconnaissance/main.py --config var/config.yml
 ```
 
 ```bash
-python simulated_asset/asset.py --config simulated_asset/var/config.yml
+python simulated_asset/asset.py --config var/config.yml
 ```
 
 ```bash
-python simulated_track/track.py --config simulated_track/var/config.yml
+python simulated_track/track.py --config var/config.yml
 ```
 
 Navigate to your Lattice UI and observe the `Active Tasks` tab. When assets come within range of a non-friendly track, an investigation task will be created. If you observe the simulated asset and track, you will see that the auto reconnaissance system will classify the track disposition as suspicious, and a task will be created for the asset to investigate the track. 

--- a/auto-reconnaissance/main.py
+++ b/auto-reconnaissance/main.py
@@ -12,6 +12,9 @@ def validate_config(cfg):
         raise ValueError("missing lattice-ip")
     if "lattice-bearer-token" not in cfg:
         raise ValueError("missing lattice-bearer-token")
+    if "sandboxes-token" not in cfg or cfg["sandboxes-token"] == "<SANDBOXES_TOKEN>":
+        logger.warning("sandboxes-token not set - required for connecting to Lattice Sandboxes")
+        cfg["sandboxes-token"] = None
 
 
 def parse_arguments():
@@ -34,7 +37,7 @@ async def main_async(cfg):
     logger.info("starting entity auto reconnaissance system")
     try:
         # Set up the application with the config
-        arbiter = Arbiter(logger, cfg["lattice-ip"], cfg["lattice-bearer-token"])
+        arbiter = Arbiter(logger, cfg["lattice-ip"], cfg["lattice-bearer-token"], cfg["sandboxes-token"])
         await arbiter.start()
     except (KeyboardInterrupt, SystemExit):
         logger.info("shutting down entity auto reconnaissance system")

--- a/auto-reconnaissance/services/arbiter.py
+++ b/auto-reconnaissance/services/arbiter.py
@@ -1,5 +1,7 @@
 import asyncio
+
 from logging import Logger
+from typing import Optional
 
 from utils.distance_calculator import DistanceCalculator
 
@@ -11,11 +13,11 @@ DISTANCE_THRESHOLD_MILES = 5
 
 
 class Arbiter:
-    def __init__(self, logger: Logger, lattice_ip: str, bearer_token: str):
+    def __init__(self, logger: Logger, lattice_ip: str, bearer_token: str, sandboxes_token: Optional[str] = None):
         self.logger = logger
-        self.entity_handler = EntityHandler(logger, lattice_ip, bearer_token)
+        self.entity_handler = EntityHandler(logger, lattice_ip, bearer_token, sandboxes_token)
         self.cache_manager = CacheManager()
-        self.tasker = Tasker(logger, lattice_ip, bearer_token)
+        self.tasker = Tasker(logger, lattice_ip, bearer_token, sandboxes_token)
 
     async def start(self):
         tasks = [

--- a/auto-reconnaissance/services/entity_handler.py
+++ b/auto-reconnaissance/services/entity_handler.py
@@ -1,16 +1,20 @@
 import asyncio
+
 from datetime import datetime, timezone
 from logging import Logger
+from typing import Optional
 
 import entities_api as anduril_entities
 
 
 class EntityHandler:
-    def __init__(self, logger: Logger, lattice_ip: str, bearer_token: str):
+    def __init__(self, logger: Logger, lattice_ip: str, bearer_token: str, sandboxes_token: Optional[str] = None):
         self.logger = logger
         self.config = anduril_entities.Configuration(host=f"https://{lattice_ip}/api/v1")
         self.api_client = anduril_entities.ApiClient(configuration=self.config, header_name="Authorization",
                                                      header_value=f"Bearer {bearer_token}")
+        if sandboxes_token:
+            self.api_client.default_headers["anduril-sandbox-authorization"] = f"Bearer {sandboxes_token}"
         self.entity_api = anduril_entities.EntityApi(api_client=self.api_client)
 
     def filter_entity(self, entity: anduril_entities.Entity) -> bool:

--- a/auto-reconnaissance/services/tasker.py
+++ b/auto-reconnaissance/services/tasker.py
@@ -3,13 +3,17 @@ from logging import Logger
 import entities_api as anduril_entities
 import tasks_api as anduril_tasks
 
+from typing import Optional
+
 
 class Tasker:
-    def __init__(self, logger: Logger, lattice_ip: str, bearer_token: str):
+    def __init__(self, logger: Logger, lattice_ip: str, bearer_token: str, sandboxes_token: Optional[str] = None):
         self.logger = logger
         self.config = anduril_tasks.Configuration(host=f"https://{lattice_ip}/api/v1")
         self.api_client = anduril_tasks.ApiClient(configuration=self.config, header_name="Authorization",
                                                   header_value=f"Bearer {bearer_token}")
+        if sandboxes_token:
+            self.api_client.default_headers["anduril-sandbox-authorization"] = f"Bearer {sandboxes_token}"
         self.task_api = anduril_tasks.TaskApi(api_client=self.api_client)
 
     def investigate(self, asset: anduril_entities.Entity, track: anduril_entities.Entity) -> str:

--- a/auto-reconnaissance/var/config.yml
+++ b/auto-reconnaissance/var/config.yml
@@ -1,4 +1,0 @@
-# lattice dns/ip (without `https://` protocol prefix)
-lattice-ip: <LATTICE DNS/IP>
-# lattice-bearer-token
-lattice-bearer-token: <LATTICE BEARER TOKEN>

--- a/simulated_asset/asset.py
+++ b/simulated_asset/asset.py
@@ -162,10 +162,10 @@ def validate_config(cfg):
         raise ValueError("missing lattice-ip")
     if "lattice-bearer-token" not in cfg:
         raise ValueError("missing lattice-bearer-token")
-    if "latitude" not in cfg:
-        raise ValueError("missing latitude")
-    if "longitude" not in cfg:
-        raise ValueError("missing longitude")
+    if "asset-latitude" not in cfg:
+        raise ValueError("missing asset-latitude")
+    if "asset-longitude" not in cfg:
+        raise ValueError("missing asset-longitude")
 
 
 def parse_arguments():
@@ -207,7 +207,7 @@ def main():
         entities_api,
         tasks_api,
         "asset-01",
-        {"latitude": cfg['latitude'], "longitude": cfg['longitude']})
+        {"latitude": cfg['asset-latitude'], "longitude": cfg['asset-longitude']})
 
     try:
         asyncio.run(asset.run())

--- a/simulated_asset/asset.py
+++ b/simulated_asset/asset.py
@@ -194,12 +194,16 @@ def main():
     entities_api_client = anduril_entities.ApiClient(configuration=entities_configuration,
                                                      header_name="Authorization",
                                                      header_value=f"Bearer {cfg['lattice-bearer-token']}")
+    if cfg["sandboxes-token"] != "<SANDBOXES_TOKEN>":
+        entities_api_client.default_headers["anduril-sandbox-authorization"] = f"Bearer {cfg['sandboxes-token']}"
     entities_api = anduril_entities.EntityApi(api_client=entities_api_client)
 
     tasks_configuration = anduril_tasks.Configuration(host=f"https://{cfg['lattice-ip']}/api/v1")
     tasks_api_client = anduril_tasks.ApiClient(configuration=tasks_configuration,
                                                header_name="Authorization",
                                                header_value=f"Bearer {cfg['lattice-bearer-token']}")
+    if cfg["sandboxes-token"] != "<SANDBOXES_TOKEN>":
+        tasks_api_client.default_headers["anduril-sandbox-authorization"] = f"Bearer {cfg['sandboxes-token']}"
     tasks_api = anduril_tasks.TaskApi(api_client=tasks_api_client)
 
     asset = SimulatedAsset(

--- a/simulated_asset/var/config.yml
+++ b/simulated_asset/var/config.yml
@@ -1,7 +1,0 @@
-# lattice dns/ip (without `https://` protocol prefix)
-lattice-ip: <LATTICE DNS/IP>
-# lattice-bearer-token
-lattice-bearer-token: <LATTICE BEARER TOKEN>
-# asset latitude and longitude
-latitude: 1
-longitude: 1

--- a/simulated_track/track.py
+++ b/simulated_track/track.py
@@ -16,10 +16,10 @@ def validate_config(cfg):
         raise ValueError("missing lattice-ip")
     if "lattice-bearer-token" not in cfg:
         raise ValueError("missing lattice-bearer-token")
-    if "latitude" not in cfg:
-        raise ValueError("missing latitude")
-    if "longitude" not in cfg:
-        raise ValueError("missing longitude")
+    if "track-latitude" not in cfg:
+        raise ValueError("missing track-latitude")
+    if "track-longitude" not in cfg:
+        raise ValueError("missing track-longitude")
 
 
 def parse_arguments():
@@ -73,8 +73,8 @@ def start_track_publishing():
     args = parse_arguments()
     cfg = read_config(args.config)
 
-    latitude = cfg['latitude']
-    longitude = cfg['longitude']
+    latitude = cfg['track-latitude']
+    longitude = cfg['track-longitude']
 
     entities_configuration = anduril_entities.Configuration(host=f"https://{cfg['lattice-ip']}/api/v1")
     entities_api_client = anduril_entities.ApiClient(configuration=entities_configuration,

--- a/simulated_track/track.py
+++ b/simulated_track/track.py
@@ -75,11 +75,14 @@ def start_track_publishing():
 
     latitude = cfg['track-latitude']
     longitude = cfg['track-longitude']
+    sandboxes_token = cfg['sandboxes-token']
 
     entities_configuration = anduril_entities.Configuration(host=f"https://{cfg['lattice-ip']}/api/v1")
     entities_api_client = anduril_entities.ApiClient(configuration=entities_configuration,
                                                      header_name="Authorization",
                                                      header_value=f"Bearer {cfg['lattice-bearer-token']}")
+    if sandboxes_token != "<SANDBOXES_TOKEN>":
+            entities_api_client.default_headers["Anduril-Sandbox-Authorization"] = f"Bearer {sandboxes_token}"
     entities_api = anduril_entities.EntityApi(api_client=entities_api_client)
 
     entity_id = str(uuid.uuid4())

--- a/var/config.yml
+++ b/var/config.yml
@@ -1,7 +1,13 @@
 # lattice dns/ip (without `https://` protocol prefix)
 lattice-ip: <LATTICE DNS/IP>
+
 # lattice-bearer-token
 lattice-bearer-token: <LATTICE BEARER TOKEN>
+
+# asset latitude and longitude
+asset-latitude: 1
+asset-longitude: 1
+
 # track latitude and longitude
-latitude: 1.03
-longitude: 1.03
+track-latitude: 1.03
+track-longitude: 1.03

--- a/var/config.yml
+++ b/var/config.yml
@@ -4,6 +4,9 @@ lattice-ip: <LATTICE DNS/IP>
 # lattice-bearer-token
 lattice-bearer-token: <LATTICE BEARER TOKEN>
 
+# sandboxes-token
+sandboxes-token: <SANDBOXES_TOKEN>
+
 # asset latitude and longitude
 asset-latitude: 1
 asset-longitude: 1


### PR DESCRIPTION
We can keep all of the config in one `config.yml` so the tokens don't need to be set in 3 separate places. 