### PR TITLE
feat: exercise degradation preflight with stale entity gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
           python auto-reconnaissance/main.py --help
           python simulated_asset/asset.py --help
           python simulated_track/track.py --help
+
+      - name: Stream health unit tests
+        run: python -m unittest discover -s tests -p 'test_*.py'

--- a/README.md
+++ b/README.md
@@ -87,3 +87,17 @@ Here is a screenshot of this in action:
 ![img](/static/auto_recon_asset_investigate_track_example.png)
 
 Congrats, you've tasked an asset to investigate a track!
+
+## Exercise degradation and mesh preflight
+
+Before live exercise hours, rehearse what happens when the entity stream gaps (relay loss, edge partition, publisher crash). The arbiter can **withhold `Investigate` tasks** when asset or track entities exceed a freshness threshold.
+
+See [`docs/EXERCISE_DEGRADATION.md`](docs/EXERCISE_DEGRADATION.md) and [`examples/relay-loss/scenario.yml`](examples/relay-loss/scenario.yml).
+
+Quick enable — add to `var/config.yml`:
+
+```yaml
+entity-stale-seconds: 120
+```
+
+Then stop `simulated_track/track.py` after tasks are flowing to simulate mesh degradation; the arbiter logs `STALE ENTITY` and skips new investigations.

--- a/auto-reconnaissance/main.py
+++ b/auto-reconnaissance/main.py
@@ -50,6 +50,7 @@ async def main_async(cfg):
             cfg["lattice-client-id"],
             cfg["lattice-client-secret"],
             cfg["sandboxes-token"],
+            entity_stale_seconds=cfg.get("entity-stale-seconds"),
         )
         await arbiter.start()
     except (KeyboardInterrupt, SystemExit):

--- a/auto-reconnaissance/services/arbiter.py
+++ b/auto-reconnaissance/services/arbiter.py
@@ -7,6 +7,7 @@ from utils.distance_calculator import DistanceCalculator
 
 from services.cache_manager import CacheManager
 from services.entity_handler import EntityHandler
+from services.stream_health import EntityStreamHealth
 from services.tasker import Tasker
 
 DISTANCE_THRESHOLD_MILES = 5
@@ -20,8 +21,11 @@ class Arbiter:
         client_id: str,
         client_secret: str,
         sandboxes_token: Optional[str] = None,
+        entity_stale_seconds: Optional[float] = None,
     ):
         self.logger = logger
+        self.entity_stale_seconds = entity_stale_seconds
+        self.stream_health = EntityStreamHealth()
         self.entity_handler = EntityHandler(
             logger, lattice_endpoint, client_id, client_secret, sandboxes_token
         )
@@ -47,6 +51,7 @@ class Arbiter:
     async def consume_entities(self):
         try:
             async for entity in self.entity_handler.stream_entities():
+                self.stream_health.record(entity.entity_id)
                 self.cache_manager.handle_response(entity)
         except asyncio.CancelledError:
             print("Streaming cancelled...")
@@ -80,6 +85,20 @@ class Arbiter:
                 self.cache_manager.remove_track_task(track.entity_id)
         return skip
 
+    def entities_fresh(self, asset, track) -> bool:
+        if self.entity_stale_seconds is None:
+            return True
+        for entity in (asset, track):
+            gap = self.stream_health.seconds_since(entity.entity_id)
+            if self.stream_health.is_stale(entity.entity_id, self.entity_stale_seconds):
+                self.logger.warning(
+                    "STALE ENTITY — skipping Investigate task "
+                    f"(entity={entity.entity_id}, gap_s={gap if gap is not None else 'never_seen'}, "
+                    f"threshold_s={self.entity_stale_seconds})"
+                )
+                return False
+        return True
+
     async def arbitrate_isr(self):
         assets = self.cache_manager.get_assets()
         tracks = self.cache_manager.get_tracks()
@@ -102,6 +121,8 @@ class Arbiter:
                         await self.entity_handler.override_track_disposition(track)
                     if self.check_in_progress(asset, track):
                         self.logger.info("INVESTIGATION ALREADY IN PROGRESS - SKIPPING")
+                        continue
+                    if not self.entities_fresh(asset, track):
                         continue
                     if (
                         self.cache_manager.get_asset_tasks(asset.entity_id) is None

--- a/auto-reconnaissance/services/stream_health.py
+++ b/auto-reconnaissance/services/stream_health.py
@@ -1,0 +1,28 @@
+"""Track entity freshness from the Lattice entity stream."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+class EntityStreamHealth:
+    """Records last-seen timestamps for streamed entities."""
+
+    def __init__(self) -> None:
+        self._last_seen: dict[str, datetime] = {}
+
+    def record(self, entity_id: str, seen_at: datetime | None = None) -> None:
+        self._last_seen[entity_id] = seen_at or datetime.now(timezone.utc)
+
+    def seconds_since(self, entity_id: str, now: datetime | None = None) -> float | None:
+        seen = self._last_seen.get(entity_id)
+        if seen is None:
+            return None
+        current = now or datetime.now(timezone.utc)
+        return (current - seen).total_seconds()
+
+    def is_stale(self, entity_id: str, max_stale_seconds: float, now: datetime | None = None) -> bool:
+        gap = self.seconds_since(entity_id, now)
+        if gap is None:
+            return True
+        return gap > max_stale_seconds

--- a/docs/EXERCISE_DEGRADATION.md
+++ b/docs/EXERCISE_DEGRADATION.md
@@ -1,0 +1,38 @@
+# Exercise degradation and mesh preflight
+
+Live exercises often fail in the gap between **sandbox CI** (asset + track simulators running on a stable network) and **field mesh** (relay loss, entity stream gaps, stale fusion). This sample app can gate `Investigate` task creation when streamed entities go stale — a lightweight preflight hook before exercise hours.
+
+## Enable stale-entity gating
+
+Add to `var/config.yml`:
+
+```yaml
+# Optional: block Investigate tasks when asset/track not seen on the entity stream
+# within this many seconds. Omit or comment out to preserve default behavior.
+entity-stale-seconds: 120
+```
+
+Restart the auto-reconnaissance arbiter after changing config.
+
+When stale, the arbiter logs:
+
+```
+WARNING:EARS:STALE ENTITY — skipping Investigate task (entity=..., gap_s=..., threshold_s=120)
+```
+
+## Simulate relay loss locally
+
+1. Start arbiter, simulated asset, and simulated track as in the main README.
+2. Confirm an `Investigate` task is created when the track is in range.
+3. **Stop** `simulated_track/track.py` (or `simulated_asset/asset.py`) — simulates mesh partition / publisher loss.
+4. With `entity-stale-seconds` set, the arbiter stops creating new tasks once the entity exceeds the threshold.
+
+This mirrors exercise scenarios where a relay drops and long-poll consumers retain last-known entity state while fusion desyncs.
+
+## Example scenario fixture
+
+See [`examples/relay-loss/scenario.yml`](relay-loss/scenario.yml) for a documented relay-death timeline (T+14h node loss) aligned with mesh exercise rehearsal workflows.
+
+## Related work
+
+For full **plan → run → doctor → report** exercise fate tooling, see [lattice-exercise-twin](https://github.com/Abhishek21g/lattice-exercise-twin) (community companion — not an Anduril product).

--- a/examples/relay-loss/scenario.yml
+++ b/examples/relay-loss/scenario.yml
@@ -1,0 +1,49 @@
+# Relay loss exercise scenario (fixture)
+
+Documented timeline for rehearsing entity stream gaps before a live exercise.
+Use with `entity-stale-seconds: 120` in `var/config.yml`.
+
+```yaml
+name: relay-death-t14
+description: >
+  Relay node lost at T+14h during exercise. Entity publishers on edge/sensor
+  nodes may continue locally but the arbiter's entity stream gaps — Investigate
+  tasks should not fire on stale fusion state.
+
+duration_hours: 72
+
+entities:
+  - id: asset-alpha
+    template: TEMPLATE_ASSET
+    publisher: uav-orin-07
+  - id: track-hostile-1
+    template: TEMPLATE_TRACK
+    disposition: DISPOSITION_HOSTILE
+    publisher: tower-12
+
+mesh:
+  nodes:
+    - id: relay-3
+      role: relay
+    - id: uav-orin-07
+      role: edge
+    - id: tower-12
+      role: sensor
+  timeline:
+    - at_hour: 14
+      event: node_loss
+      node: relay-3
+      detail: relay lost during exercise
+
+preflight:
+  entity_stale_seconds: 120
+  expected_behavior: >
+    After stopping simulated_track (or asset) updates for >120s, arbiter skips
+    new Investigate tasks and logs STALE ENTITY warnings.
+
+local_simulation:
+  steps:
+    - Run arbiter + simulated_asset + simulated_track
+    - Verify Investigate task in Lattice UI
+    - Stop simulated_track to simulate publisher/stream gap
+    - Confirm arbiter withholds further Investigate tasks

--- a/tests/test_stream_health.py
+++ b/tests/test_stream_health.py
@@ -1,0 +1,30 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "auto-reconnaissance"))
+
+from services.stream_health import EntityStreamHealth  # noqa: E402
+
+
+class EntityStreamHealthTest(unittest.TestCase):
+    def test_fresh_entity_not_stale(self):
+        health = EntityStreamHealth()
+        now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        health.record("asset-1", now)
+        self.assertFalse(health.is_stale("asset-1", 120, now + timedelta(seconds=30)))
+
+    def test_old_entity_is_stale(self):
+        health = EntityStreamHealth()
+        now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        health.record("track-1", now)
+        self.assertTrue(health.is_stale("track-1", 60, now + timedelta(seconds=61)))
+
+    def test_never_seen_is_stale(self):
+        health = EntityStreamHealth()
+        self.assertTrue(health.is_stale("missing", 10))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds optional `entity-stale-seconds` config to withhold `Investigate` tasks when asset/track entities gap on the entity stream
- Introduces `EntityStreamHealth` tracker + arbiter gate (default off — existing behavior unchanged)
- Documents mesh preflight workflow in `docs/EXERCISE_DEGRADATION.md` and `examples/relay-loss/scenario.yml`
- Adds stream health unit tests to CI

This extends the auto-recon sample for exercise rehearsal: stop `simulated_track` to simulate relay/publisher loss and confirm the arbiter does not task on stale fusion state.

## Test plan
- [x] `python -m unittest discover -s tests -p 'test_*.py'`
- [x] `python auto-reconnaissance/main.py --help`
- [ ] Sandbox: run arbiter + simulators with `entity-stale-seconds: 120`, stop track publisher, confirm `STALE ENTITY` log and no new tasks